### PR TITLE
Add examples for menu choices

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,12 @@ By default the choice name is also the value the prompt will return when selecte
 
 ```ruby
 choices = {small: 1, medium: 2, large: 3}
+prompt.select("What size?", choices)
+# =>
+What sie? (Press ↑/↓ arrow to move and Enter to select)
+‣ small
+  medium
+  large
 ```
 
 Finally, you can define an array of choices where each choice is a hash value with `:name` & `:value` keys which can include other options for customising individual choices:
@@ -633,6 +639,11 @@ prompt.select("What size?") do |menu|
   menu.choice name: "medium", value: 2, disabled: "(out of stock)"
   menu.choice name: "large",  value: 3
 end
+# =>
+What size? (Press ↑/↓ arrow to move and Enter to select)
+‣ small
+✘ medium (out of stock)
+  large
 ```
 
 or in a more compact way:

--- a/README.md
+++ b/README.md
@@ -613,10 +613,10 @@ By default the choice name is also the value the prompt will return when selecte
 choices = {small: 1, medium: 2, large: 3}
 prompt.select("What size?", choices)
 # =>
-What sie? (Press ↑/↓ arrow to move and Enter to select)
-‣ small
-  medium
-  large
+# What size? (Press ↑/↓ arrow to move and Enter to select)
+# ‣ small
+#   medium
+#   large
 ```
 
 Finally, you can define an array of choices where each choice is a hash value with `:name` & `:value` keys which can include other options for customising individual choices:
@@ -640,10 +640,10 @@ prompt.select("What size?") do |menu|
   menu.choice name: "large",  value: 3
 end
 # =>
-What size? (Press ↑/↓ arrow to move and Enter to select)
-‣ small
-✘ medium (out of stock)
-  large
+# What size? (Press ↑/↓ arrow to move and Enter to select)
+# ‣ small
+# ✘ medium (out of stock)
+#   large
 ```
 
 or in a more compact way:


### PR DESCRIPTION
### Describe the change
Add examples for menu - choices

### Why are we doing this?
At the beginning of the [menu section](https://github.com/piotrmurach/tty-prompt#261-choices), it helps to have some examples to visualize how the prompt would look like.

### Benefits
How will the library improve?

The documentation would be easier to understand with more examples.

### Drawbacks
Possible drawbacks applying this change. - none

### Requirements
Put an X between brackets on each line if you have done the item:
[] Tests written & passing locally? - not applicable
[] Code style checked?- not applicable
[X] Rebased with `master` branch?
[X] Documentation updated?
